### PR TITLE
Investigate mermaid errors in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,9 +37,9 @@ repos:
     hooks:
       - id: validate-mermaid
         name: Validate Mermaid diagrams
-        entry: bash -c "cd docs && node scripts/validate-mermaid.js"
+        entry: bash -c "node docs/scripts/validate-mermaid.js ."
         language: system
-        files: '^docs/.*\.md$'
+        files: '.*\.md$'
         pass_filenames: false
       
       - id: docusaurus-build

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,28 +32,24 @@ The system follows a modular, plugin-based architecture with clear separation of
 ```mermaid
 graph TB
     subgraph "Entry Points Layer"
-        style "Entry Points Layer" fill:#e1f5fe,stroke:#01579b,stroke-width:2px
         A1[Demo Scripts]:::entrypoint
         A2[Evaluation Tools]:::entrypoint
         A3[Comparison Utilities]:::entrypoint
     end
     
     subgraph "Orchestration Layer"
-        style "Orchestration Layer" fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
         B1[ComprehensiveFieldDetector]:::orchestrator
         B2[Evaluator]:::orchestrator
         B3[Comparator]:::orchestrator
     end
     
     subgraph "Detection Methods Layer"
-        style "Detection Methods Layer" fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
         C1[Validation<br/>Rule-based]:::validator
         C2[Pattern-Based<br/>Anomaly]:::detector
         C3[ML/LLM-Based<br/>Semantic]:::ml
     end
     
     subgraph "Core Services Layer"
-        style "Core Services Layer" fill:#fff3e0,stroke:#e65100,stroke-width:2px
         D1[FieldMapper]:::service
         D2[BrandConfig]:::service
         D3[ErrorInjector]:::service
@@ -61,7 +57,6 @@ graph TB
     end
     
     subgraph "Data Layer"
-        style "Data Layer" fill:#f5f5f5,stroke:#424242,stroke-width:2px
         E1[CSV Files]:::data
         E2[JSON Configs]:::data
         E3[Model Files]:::data

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -21,14 +21,12 @@ Configurable thresholds, weights, and field mappings allow the system to adapt t
 ```mermaid
 graph TB
     subgraph "User Interface"
-        style "User Interface" fill:#e3f2fd,stroke:#0d47a1,stroke-width:2px
         UI1[CLI Tools]:::ui
         UI2[HTML Viewer]:::ui
         UI3[API Endpoints]:::ui
     end
     
     subgraph "Entry Points"
-        style "Entry Points" fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
         EP1[single_sample_demo]:::entry
         EP2[multi_sample_evaluation]:::entry
         EP3[ml_curve_generator]:::entry
@@ -36,14 +34,12 @@ graph TB
     end
     
     subgraph "Orchestration"
-        style "Orchestration" fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
         O1[ComprehensiveFieldDetector]:::orchestrator
         O2[ConsolidatedReporter]:::orchestrator
         O3[ConfusionMatrixAnalyzer]:::orchestrator
     end
     
     subgraph "Detection Engine"
-        style "Detection Engine" fill:#fff8e1,stroke:#f57f17,stroke-width:2px
         DE1[Validation Engine]:::validator
         DE2[Pattern Detector]:::detector
         DE3[ML Detector]:::ml
@@ -51,7 +47,6 @@ graph TB
     end
     
     subgraph "Core Services"
-        style "Core Services" fill:#fce4ec,stroke:#880e4f,stroke-width:2px
         CS1[Field Mapper]:::service
         CS2[Brand Config]:::service
         CS3[Error Injector]:::service
@@ -59,7 +54,6 @@ graph TB
     end
     
     subgraph "Data Storage"
-        style "Data Storage" fill:#eceff1,stroke:#263238,stroke-width:2px
         DS1[(CSV Data)]:::storage
         DS2[(JSON Configs)]:::storage
         DS3[(ML Models)]:::storage
@@ -113,7 +107,6 @@ Implements the core detection algorithms:
 ```mermaid
 graph LR
     subgraph "Detection Methods"
-        style "Detection Methods" fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
         V[Validation<br/>100% Confidence]:::validator
         P[Pattern-Based<br/>70-80% Confidence]:::pattern
         M[ML-Based<br/>Configurable]:::ml

--- a/docs/consolidated/architecture-design.md
+++ b/docs/consolidated/architecture-design.md
@@ -26,14 +26,12 @@ Clear boundaries between layers ensure maintainability and testability.
 ```mermaid
 graph TB
     subgraph "User Interface"
-        style "User Interface" fill:#e3f2fd,stroke:#0d47a1,stroke-width:2px
         UI1[CLI Tools]:::ui
         UI2[HTML Viewer]:::ui
         UI3[API Endpoints]:::ui
     end
     
     subgraph "Entry Points"
-        style "Entry Points" fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
         EP1[single_sample_demo]:::entry
         EP2[multi_sample_evaluation]:::entry
         EP3[ml_curve_generator]:::entry
@@ -41,14 +39,12 @@ graph TB
     end
     
     subgraph "Orchestration"
-        style "Orchestration" fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
         O1[ComprehensiveFieldDetector]:::orchestrator
         O2[ConsolidatedReporter]:::orchestrator
         O3[ConfusionMatrixAnalyzer]:::orchestrator
     end
     
     subgraph "Detection Engine"
-        style "Detection Engine" fill:#fff8e1,stroke:#f57f17,stroke-width:2px
         DE1[Validation Engine]:::validator
         DE2[Pattern Detector]:::detector
         DE3[ML Detector]:::ml
@@ -56,7 +52,6 @@ graph TB
     end
     
     subgraph "Core Services"
-        style "Core Services" fill:#fce4ec,stroke:#880e4f,stroke-width:2px
         CS1[Field Mapper]:::service
         CS2[Brand Config]:::service
         CS3[Error Injector]:::service
@@ -64,7 +59,6 @@ graph TB
     end
     
     subgraph "Data Storage"
-        style "Data Storage" fill:#eceff1,stroke:#263238,stroke-width:2px
         DS1[(CSV Data)]:::storage
         DS2[(JSON Configs)]:::storage
         DS3[(ML Models)]:::storage
@@ -118,7 +112,6 @@ Implements the core detection algorithms:
 ```mermaid
 graph LR
     subgraph "Detection Methods"
-        style "Detection Methods" fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
         V[Validation<br/>100% Confidence]:::validator
         P[Pattern-Based<br/>70-80% Confidence]:::pattern
         M[ML-Based<br/>Configurable]:::ml

--- a/docs/consolidated/introduction-overview.md
+++ b/docs/consolidated/introduction-overview.md
@@ -49,28 +49,24 @@ The system follows a modular, layered architecture with clear separation of conc
 ```mermaid
 graph TB
     subgraph "Entry Points Layer"
-        style "Entry Points Layer" fill:#e1f5fe,stroke:#01579b,stroke-width:2px
         A1[Demo Scripts]:::entrypoint
         A2[Evaluation Tools]:::entrypoint
         A3[Comparison Utilities]:::entrypoint
     end
     
     subgraph "Orchestration Layer"
-        style "Orchestration Layer" fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
         B1[ComprehensiveFieldDetector]:::orchestrator
         B2[Evaluator]:::orchestrator
         B3[Comparator]:::orchestrator
     end
     
     subgraph "Detection Methods Layer"
-        style "Detection Methods Layer" fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px
         C1[Validation<br/>Rule-based]:::validator
         C2[Pattern-Based<br/>Anomaly]:::detector
         C3[ML/LLM-Based<br/>Semantic]:::ml
     end
     
     subgraph "Core Services Layer"
-        style "Core Services Layer" fill:#fff3e0,stroke:#e65100,stroke-width:2px
         D1[FieldMapper]:::service
         D2[BrandConfig]:::service
         D3[ErrorInjector]:::service
@@ -78,7 +74,6 @@ graph TB
     end
     
     subgraph "Data Layer"
-        style "Data Layer" fill:#f5f5f5,stroke:#424242,stroke-width:2px
         E1[CSV Files]:::data
         E2[JSON Configs]:::data
         E3[Model Files]:::data

--- a/docs/scripts/validate-mermaid.js
+++ b/docs/scripts/validate-mermaid.js
@@ -93,6 +93,15 @@ function validateDiagram(diagram) {
       errors.push(`Unbalanced brackets: ${openBrackets} opening, ${closeBrackets} closing`);
     }
     
+    // Check for invalid style commands with quoted subgraph names
+    lines.forEach((line, index) => {
+      const trimmedLine = line.trim();
+      // Match style commands with quoted names
+      if (trimmedLine.match(/^style\s+"[^"]+"\s+/)) {
+        errors.push(`Line ${index + 1}: Invalid style syntax - cannot use quoted names with style command. Use: style subgraphId fill:...`);
+      }
+    });
+    
     // Check for common syntax errors
     if (diagram.content.includes('→')) {
       errors.push('Contains Unicode arrow (→). Use --> instead');
@@ -121,8 +130,9 @@ function validateDiagram(diagram) {
 function validateAllDiagrams() {
   console.log(`${colors.blue}🔍 Validating Mermaid diagrams in documentation...${colors.reset}\n`);
   
-  const docsDir = path.resolve(__dirname, '..');
-  const markdownFiles = findMarkdownFiles(docsDir);
+  // Get directory from command line argument or default to docs
+  const targetDir = process.argv[2] || path.resolve(__dirname, '..');
+  const markdownFiles = findMarkdownFiles(targetDir);
   
   let totalDiagrams = 0;
   let totalErrors = 0;
@@ -139,7 +149,7 @@ function validateAllDiagrams() {
       if (errors.length > 0) {
         totalErrors += errors.length;
         errorDetails.push({
-          file: path.relative(docsDir, diagram.file),
+          file: path.relative(targetDir, diagram.file),
           line: diagram.line,
           errors: errors
         });
@@ -172,8 +182,9 @@ function validateAllDiagrams() {
 function checkForASCIIArt() {
   console.log(`${colors.blue}🔍 Checking for ASCII art diagrams...${colors.reset}\n`);
   
-  const docsDir = path.resolve(__dirname, '..');
-  const markdownFiles = findMarkdownFiles(docsDir);
+  // Get directory from command line argument or default to docs
+  const targetDir = process.argv[2] || path.resolve(__dirname, '..');
+  const markdownFiles = findMarkdownFiles(targetDir);
   
   const asciiPatterns = [
     /[│├└─┌┐┘┤┬┴┼━┃┏┓┗┛┣┫┳┻╋]/,  // Box drawing characters
@@ -208,7 +219,7 @@ function checkForASCIIArt() {
           
           if (!insideCodeBlock) {
             findings.push({
-              file: path.relative(docsDir, file),
+              file: path.relative(targetDir, file),
               line: index + 1,
               content: line.trim()
             });


### PR DESCRIPTION
Fixes invalid Mermaid diagram syntax and enhances pre-commit validation to catch such errors across all markdown files.

The original pre-commit hook for Mermaid validation was limited: it only checked files in the `docs/` directory and its validation script didn't specifically catch the `style "Subgraph Name"` syntax error. This PR corrects the existing invalid Mermaid syntax and updates the pre-commit hook to validate all markdown files for this and other common Mermaid issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-579c4e1e-c156-47cf-86c8-94d34d33b9cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-579c4e1e-c156-47cf-86c8-94d34d33b9cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

