### PR TITLE
Investigate pdf generation error

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -49,6 +49,38 @@ jobs:
         run: npm ci
         working-directory: ./docs
 
+      - name: Install Chrome dependencies for PDF generation
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            fonts-liberation \
+            libappindicator3-1 \
+            libasound2 \
+            libatk-bridge2.0-0 \
+            libatk1.0-0 \
+            libcups2 \
+            libdbus-1-3 \
+            libdrm2 \
+            libgbm1 \
+            libgtk-3-0 \
+            libnspr4 \
+            libnss3 \
+            libu2f-udev \
+            libvulkan1 \
+            libx11-xcb1 \
+            libxcomposite1 \
+            libxdamage1 \
+            libxfixes3 \
+            libxrandr2 \
+            libxss1 \
+            libxtst6 \
+            libxtst6 \
+            xdg-utils \
+            ca-certificates \
+            chromium-browser
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
       - name: Generate sidebars
         run: node scripts/generate-sidebars.js
         working-directory: ./docs
@@ -56,6 +88,10 @@ jobs:
       - name: Build website
         run: npm run build
         working-directory: ./docs
+        env:
+          # Puppeteer configuration for CI
+          PUPPETEER_ARGS: "--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-accelerated-2d-canvas,--no-first-run,--no-zygote,--disable-gpu"
+          PUPPETEER_EXECUTABLE_PATH: "/usr/bin/chromium-browser"
 
       - name: Setup Pages
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "validate-mermaid": "node scripts/validate-mermaid.js",
     "prebuild": "npm run validate-mermaid",
-    "postbuild": "npm run generate-pdf",
+    "postbuild": "echo 'Starting PDF generation...' && npm run generate-pdf",
     "generate-pdf": "node scripts/generate-pdf-with-server.js"
   },
   "dependencies": {

--- a/docs/scripts/generate-pdf-with-server.js
+++ b/docs/scripts/generate-pdf-with-server.js
@@ -32,14 +32,23 @@ async function generatePDF() {
   await sleep(5000);
   
   try {
-    // Generate PDF using docs-to-pdf
-    const command = `npx docs-to-pdf docusaurus --initialDocURLs="http://localhost:3001/README" --outputPDFFilename="xafron-documentation.pdf" --coverTitle="Xafron Documentation" --coverSub="Data Quality Detection System<br/>Version ${new Date().getFullYear()}" --disableTOC=false --pdfMargin="20,20,20,20"`;
+    // Generate PDF using docs-to-pdf - Fix the initial URL to point to the root
+    const command = `npx docs-to-pdf docusaurus --initialDocURLs="http://localhost:3001/" --outputPDFFilename="xafron-documentation.pdf" --coverTitle="Xafron Documentation" --coverSub="Data Quality Detection System<br/>Version ${new Date().getFullYear()}" --disableTOC=false --pdfMargin="20,20,20,20"`;
     
     console.log('Generating PDF...');
+    console.log('Command:', command);
+    
+    // Set up environment for Puppeteer
+    const env = {
+      ...process.env,
+      PUPPETEER_ARGS: process.env.PUPPETEER_ARGS || '--no-sandbox,--disable-setuid-sandbox',
+      PUPPETEER_EXECUTABLE_PATH: process.env.PUPPETEER_EXECUTABLE_PATH || undefined
+    };
     
     execSync(command, {
       stdio: 'inherit',
-      cwd: path.join(__dirname, '..')
+      cwd: path.join(__dirname, '..'),
+      env: env
     });
     
     // Move the generated PDF to the correct location
@@ -56,10 +65,29 @@ async function generatePDF() {
         fs.mkdirSync(staticPdfDir, { recursive: true });
       }
       fs.copyFileSync(targetPdf, path.join(staticPdfDir, 'xafron-documentation.pdf'));
+      console.log(`PDF copied to static directory: ${path.join(staticPdfDir, 'xafron-documentation.pdf')}`);
+    } else {
+      console.error('PDF generation failed - file not found at:', generatedPdf);
     }
     
   } catch (error) {
     console.error('Error generating PDF:', error);
+    console.error('This might be due to missing browser dependencies in CI environment');
+    
+    // Create a placeholder file to prevent 404 errors
+    const staticPdfDir = path.join(__dirname, '..', 'static', 'pdf');
+    if (!fs.existsSync(staticPdfDir)) {
+      fs.mkdirSync(staticPdfDir, { recursive: true });
+    }
+    
+    // Create a simple text file explaining the issue
+    const placeholderPath = path.join(staticPdfDir, 'xafron-documentation.pdf');
+    const placeholderContent = `PDF generation failed during build.
+Please check the GitHub Actions logs for more details.
+Visit the online documentation at: https://docs.xafron.nl/`;
+    
+    fs.writeFileSync(placeholderPath, placeholderContent);
+    console.log('Created placeholder file at:', placeholderPath);
   } finally {
     // Kill the server
     try {

--- a/docs/static/pdf/.gitkeep
+++ b/docs/static/pdf/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the pdf directory is tracked in git
+# The actual PDF will be generated during the build process

--- a/docs/static/pdf/README.md
+++ b/docs/static/pdf/README.md
@@ -1,0 +1,23 @@
+# PDF Generation
+
+This directory contains the generated PDF version of the documentation.
+
+## How it works
+
+1. During the build process (`npm run build`), the `postbuild` script runs
+2. This executes `scripts/generate-pdf-with-server.js`
+3. The script starts a local Docusaurus server and uses `docs-to-pdf` to generate a PDF
+4. The PDF is placed in both `build/pdf/` and copied to `static/pdf/`
+
+## Troubleshooting
+
+If the PDF generation fails (which can happen in CI environments due to missing browser dependencies), a placeholder file will be created instead.
+
+The PDF should be accessible at: `/pdf/xafron-documentation.pdf`
+
+## Requirements
+
+PDF generation requires:
+- Chrome/Chromium browser
+- Various system libraries (automatically installed in GitHub Actions)
+- The `docs-to-pdf` npm package (listed in devDependencies)


### PR DESCRIPTION
Fix PDF generation in CI and add a fallback to prevent 404 errors.

The PDF generation was failing in GitHub Actions due to missing Chrome/Chromium dependencies and an incorrect initial URL for the `docs-to-pdf` tool. This PR installs the necessary dependencies, corrects the URL, and adds a placeholder PDF to ensure users don't encounter a 404 if generation fails.

---
<a href="https://cursor.com/background-agent?bcId=bc-54f554b7-6955-45f3-ac5c-aa0cce3e2a5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54f554b7-6955-45f3-ac5c-aa0cce3e2a5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

