### PR TITLE
Debug mermaid pdf export issue

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,8 @@
     "validate-mermaid": "node scripts/validate-mermaid.js",
     "prebuild": "npm run validate-mermaid",
     "postbuild": "echo 'Starting PDF generation...' && npm run generate-pdf",
-    "generate-pdf": "node scripts/generate-pdf-wkhtmltopdf.js"
+    "generate-pdf": "node scripts/generate-pdf-simple.js",
+    "generate-pdf-original": "node scripts/generate-pdf-wkhtmltopdf.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.0.1",

--- a/docs/print.css
+++ b/docs/print.css
@@ -154,11 +154,16 @@ blockquote {
   background-color: #ffeef0 !important;
 }
 
-/* Mermaid diagrams */
+/* Mermaid diagrams - Enhanced for PDF rendering */
 .mermaid {
   text-align: center !important;
   margin: 20px 0 !important;
   page-break-inside: avoid !important;
+  /* Ensure container is visible and stable */
+  opacity: 1 !important;
+  visibility: visible !important;
+  display: block !important;
+  min-height: 50px !important;
 }
 
 .mermaid svg {
@@ -166,27 +171,56 @@ blockquote {
   height: auto !important;
   display: block !important;
   margin: 0 auto !important;
+  /* Ensure SVG is fully rendered */
+  opacity: 1 !important;
+  visibility: visible !important;
 }
 
-/* Ensure mermaid text is visible */
+/* Ensure mermaid text is visible with proper contrast */
 .mermaid text {
-  fill: #000 !important;
+  fill: #000000 !important;
   stroke: none !important;
+  font-family: "Helvetica", "Arial", sans-serif !important;
+  font-size: 12px !important;
 }
 
-/* Ensure mermaid lines are visible */
+/* Ensure mermaid lines are visible with proper thickness */
 .mermaid path,
 .mermaid line {
-  stroke: #333 !important;
+  stroke: #333333 !important;
+  stroke-width: 1.5px !important;
+  fill: none !important;
 }
 
-/* Ensure mermaid shapes have proper fill */
+/* Ensure mermaid shapes have proper fill and stroke */
 .mermaid rect,
 .mermaid circle,
 .mermaid ellipse,
 .mermaid polygon {
-  fill: #f9f9f9 !important;
-  stroke: #333 !important;
+  fill: #ffffff !important;
+  stroke: #333333 !important;
+  stroke-width: 1.5px !important;
+}
+
+/* Fix for flowchart specific elements */
+.mermaid .node rect,
+.mermaid .node circle,
+.mermaid .node ellipse,
+.mermaid .node polygon {
+  fill: #ffffff !important;
+  stroke: #333333 !important;
+  stroke-width: 2px !important;
+}
+
+/* Ensure arrowheads are visible */
+.mermaid marker path {
+  fill: #333333 !important;
+  stroke: #333333 !important;
+}
+
+/* Fix for any background issues */
+.mermaid .background {
+  fill: transparent !important;
 }
 
 /* Ensure proper spacing */

--- a/docs/scripts/generate-pdf-alternative.js
+++ b/docs/scripts/generate-pdf-alternative.js
@@ -1,0 +1,151 @@
+const { spawn, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+async function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function testServerReady(url, maxAttempts = 30) {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const { execSync } = require('child_process');
+      execSync(`curl -s -o /dev/null -w "%{http_code}" ${url}`, { timeout: 5000 });
+      console.log(`Server is ready at ${url}`);
+      return true;
+    } catch (error) {
+      console.log(`Waiting for server... attempt ${i + 1}/${maxAttempts}`);
+      await sleep(2000);
+    }
+  }
+  throw new Error(`Server not ready after ${maxAttempts} attempts`);
+}
+
+async function generatePDFAlternative() {
+  console.log('Starting alternative PDF generation with enhanced Mermaid support...');
+  
+  const buildDir = path.join(__dirname, '..', 'build');
+  const outputDir = path.join(buildDir, 'pdf');
+  
+  // Ensure output directory exists
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  
+  // Kill any existing servers
+  try {
+    execSync('pkill -f "docusaurus serve" || true', { stdio: 'ignore' });
+  } catch (e) {
+    // Ignore errors
+  }
+  
+  // Start the docusaurus server
+  console.log('Starting Docusaurus server...');
+  const serverProcess = spawn('npx', ['docusaurus', 'serve', '--port', '3001', '--host', '0.0.0.0'], {
+    cwd: path.join(__dirname, '..'),
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  
+  serverProcess.unref();
+  
+  try {
+    // Wait for server to be ready
+    await testServerReady('http://localhost:3001');
+    
+    // Additional wait for Mermaid to initialize
+    console.log('Waiting additional time for Mermaid initialization...');
+    await sleep(5000);
+    
+    // Generate PDF using wkhtmltopdf directly
+    console.log('Generating PDF with wkhtmltopdf directly...');
+    
+    const outputPdf = path.join(outputDir, 'xafron-documentation.pdf');
+    const printCssPath = path.join(__dirname, '..', 'print.css');
+    
+    // Enhanced wkhtmltopdf command for better Mermaid support
+    const wkhtmltopdfCmd = [
+      'wkhtmltopdf',
+      '--page-size', 'A4',
+      '--orientation', 'Portrait',
+      '--margin-top', '1in',
+      '--margin-bottom', '1in',
+      '--margin-left', '0.75in',
+      '--margin-right', '0.75in',
+      '--encoding', 'UTF-8',
+      '--enable-javascript',
+      '--javascript-delay', '5000', // 5 second delay for JavaScript
+      '--no-stop-slow-scripts',
+      '--debug-javascript',
+      '--load-error-handling', 'ignore',
+      '--load-media-error-handling', 'ignore',
+      '--viewport-size', '1280x1024',
+      '--disable-smart-shrinking',
+      '--print-media-type',
+      '--user-style-sheet', printCssPath,
+      '--toc',
+      '--toc-header-text', 'Table of Contents',
+      '--toc-text-size-shrink', '0.8',
+      'http://localhost:3001',
+      outputPdf
+    ];
+    
+    console.log('Running wkhtmltopdf with enhanced options...');
+    console.log('Command:', wkhtmltopdfCmd.join(' '));
+    
+    execSync(wkhtmltopdfCmd.join(' '), {
+      stdio: 'inherit',
+      cwd: path.join(__dirname, '..')
+    });
+    
+    if (fs.existsSync(outputPdf)) {
+      console.log(`PDF generated successfully at: ${outputPdf}`);
+      
+      // Also copy to static directory
+      const staticPdfDir = path.join(__dirname, '..', 'static', 'pdf');
+      if (!fs.existsSync(staticPdfDir)) {
+        fs.mkdirSync(staticPdfDir, { recursive: true });
+      }
+      fs.copyFileSync(outputPdf, path.join(staticPdfDir, 'xafron-documentation.pdf'));
+      console.log(`PDF copied to static directory: ${path.join(staticPdfDir, 'xafron-documentation.pdf')}`);
+    } else {
+      throw new Error('PDF file was not generated');
+    }
+    
+  } catch (error) {
+    console.error('Error generating PDF:', error);
+    
+    // Provide diagnostic information
+    console.error('\nDiagnostic Information:');
+    try {
+      console.error('wkhtmltopdf version:', execSync('wkhtmltopdf --version', { encoding: 'utf8' }));
+    } catch (e) {
+      console.error('wkhtmltopdf not found or not working');
+    }
+    
+    try {
+      console.error('Server status:', execSync('curl -s -I http://localhost:3001', { encoding: 'utf8' }));
+    } catch (e) {
+      console.error('Server not accessible');
+    }
+    
+    throw error;
+  } finally {
+    // Kill the server
+    try {
+      execSync('pkill -f "docusaurus serve"', { stdio: 'ignore' });
+    } catch (e) {
+      // Server might have already stopped
+    }
+  }
+}
+
+// Run if called directly
+if (require.main === module) {
+  generatePDFAlternative().catch(error => {
+    console.error('PDF generation failed:', error);
+    process.exit(1);
+  });
+}
+
+module.exports = { generatePDFAlternative };

--- a/docs/scripts/generate-pdf-simple.js
+++ b/docs/scripts/generate-pdf-simple.js
@@ -1,0 +1,147 @@
+const { spawn, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+async function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function testServerReady(url, maxAttempts = 20) {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const result = execSync(`curl -s -o /dev/null -w "%{http_code}" ${url}`, { 
+        timeout: 5000,
+        encoding: 'utf8'
+      });
+      if (result.trim() === '200') {
+        console.log(`Server is ready at ${url}`);
+        return true;
+      }
+    } catch (error) {
+      console.log(`Waiting for server... attempt ${i + 1}/${maxAttempts}`);
+      await sleep(2000);
+    }
+  }
+  throw new Error(`Server not ready after ${maxAttempts} attempts`);
+}
+
+async function generatePDFSimple() {
+  console.log('Starting simple PDF generation...');
+  
+  const buildDir = path.join(__dirname, '..', 'build');
+  const outputDir = path.join(buildDir, 'pdf');
+  
+  // Ensure output directory exists
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  
+  // Kill any existing servers
+  try {
+    execSync('pkill -f "docusaurus serve" || true', { stdio: 'ignore' });
+  } catch (e) {
+    // Ignore errors
+  }
+  
+  // Start the docusaurus server
+  console.log('Starting Docusaurus server...');
+  const serverProcess = spawn('npx', ['docusaurus', 'serve', '--port', '3001', '--host', '0.0.0.0'], {
+    cwd: path.join(__dirname, '..'),
+    detached: true,
+    stdio: 'ignore'
+  });
+  
+  serverProcess.unref();
+  
+  try {
+    // Wait for server to be ready
+    await testServerReady('http://localhost:3001');
+    
+    // Additional wait for page to fully load and render
+    console.log('Waiting for page content to load...');
+    await sleep(10000); // Simple 10-second wait for Mermaid rendering
+    
+    // Generate PDF using basic wkhtmltopdf
+    console.log('Generating PDF with basic wkhtmltopdf...');
+    
+    const outputPdf = path.join(outputDir, 'xafron-documentation.pdf');
+    const printCssPath = path.join(__dirname, '..', 'print.css');
+    
+    // Basic wkhtmltopdf command that should work reliably
+    const wkhtmltopdfCmd = [
+      'wkhtmltopdf',
+      '--page-size', 'A4',
+      '--margin-top', '20mm',
+      '--margin-bottom', '20mm',
+      '--margin-left', '15mm',
+      '--margin-right', '15mm',
+      '--encoding', 'UTF-8',
+      '--enable-javascript',
+      '--javascript-delay', '5000', // Basic JavaScript delay
+      '--load-error-handling', 'ignore',
+      '--print-media-type',
+      '--user-style-sheet', printCssPath,
+      'http://localhost:3001',
+      outputPdf
+    ];
+    
+    const command = wkhtmltopdfCmd.join(' ');
+    console.log('Command:', command);
+    
+    execSync(command, {
+      stdio: 'inherit',
+      cwd: path.join(__dirname, '..')
+    });
+    
+    // Check if PDF was generated
+    if (fs.existsSync(outputPdf)) {
+      console.log(`PDF generated successfully at: ${outputPdf}`);
+      
+      // Also copy to static directory
+      const staticPdfDir = path.join(__dirname, '..', 'static', 'pdf');
+      if (!fs.existsSync(staticPdfDir)) {
+        fs.mkdirSync(staticPdfDir, { recursive: true });
+      }
+      fs.copyFileSync(outputPdf, path.join(staticPdfDir, 'xafron-documentation.pdf'));
+      console.log(`PDF copied to static directory: ${path.join(staticPdfDir, 'xafron-documentation.pdf')}`);
+    } else {
+      console.error('PDF generation failed - file not found at:', outputPdf);
+    }
+    
+  } catch (error) {
+    console.error('Error generating PDF:', error);
+    
+    // Provide diagnostic information
+    console.error('\nDiagnostic Information:');
+    try {
+      console.error('wkhtmltopdf version:', execSync('wkhtmltopdf --version', { encoding: 'utf8' }));
+    } catch (e) {
+      console.error('wkhtmltopdf not found or not working');
+    }
+    
+    try {
+      console.error('Server status:', execSync('curl -s -I http://localhost:3001', { encoding: 'utf8' }));
+    } catch (e) {
+      console.error('Server not accessible');
+    }
+    
+    throw error;
+  } finally {
+    // Kill the server
+    try {
+      execSync('pkill -f "docusaurus serve"', { stdio: 'ignore' });
+    } catch (e) {
+      // Server might have already stopped
+    }
+  }
+}
+
+// Run if called directly
+if (require.main === module) {
+  generatePDFSimple().catch(error => {
+    console.error('PDF generation failed:', error);
+    process.exit(1);
+  });
+}
+
+module.exports = { generatePDFSimple };

--- a/docs/scripts/generate-pdf-wkhtmltopdf.js
+++ b/docs/scripts/generate-pdf-wkhtmltopdf.js
@@ -27,15 +27,25 @@ async function generatePDF() {
   
   serverProcess.unref();
   
-  // Wait for server to start
-  console.log('Waiting for server to start...');
-  await sleep(5000);
+  // Wait for server to start and Mermaid to initialize
+  console.log('Waiting for server to start and Mermaid to initialize...');
+  await sleep(8000); // Increased wait time for Mermaid
   
   try {
-    // Generate PDF using docusaurus-wkhtmltopdf
-    console.log('Generating PDF with docusaurus-wkhtmltopdf...');
+    // Generate PDF using docusaurus-wkhtmltopdf with enhanced JavaScript handling
+    console.log('Generating PDF with enhanced Mermaid support...');
     
-    const command = 'npx docusaurus-wkhtmltopdf -u http://localhost:3001 --output xafron-documentation.pdf --compress --toc --wkhtmltopdf-args "--user-style-sheet print.css"';
+    // Enhanced wkhtmltopdf arguments for Mermaid rendering
+    const wkhtmltopdfArgs = [
+      '--user-style-sheet print.css',
+      '--enable-javascript',
+      '--javascript-delay 5000', // Wait 5 seconds for JavaScript to complete
+      '--load-error-handling ignore',
+      '--no-stop-slow-scripts',
+      '--viewport-size 1280x1024'
+    ].join(' ');
+    
+    const command = `npx docusaurus-wkhtmltopdf -u http://localhost:3001 --output xafron-documentation.pdf --compress --toc --wkhtmltopdf-args "${wkhtmltopdfArgs}"`;
     
     console.log('Command:', command);
     

--- a/docs/scripts/mermaid-wait.js
+++ b/docs/scripts/mermaid-wait.js
@@ -1,0 +1,108 @@
+/**
+ * Client-side script to wait for all Mermaid diagrams to be fully rendered
+ * This script runs in the browser and sets a flag when all diagrams are ready
+ */
+(function() {
+  'use strict';
+  
+  console.log('Mermaid wait script started');
+  
+  function waitForMermaidDiagrams() {
+    return new Promise((resolve) => {
+      let checkCount = 0;
+      const maxChecks = 50; // Maximum 25 seconds (50 * 500ms)
+      
+      function checkMermaidStatus() {
+        checkCount++;
+        console.log(`Checking Mermaid status... attempt ${checkCount}`);
+        
+        // Find all mermaid containers
+        const mermaidContainers = document.querySelectorAll('.mermaid');
+        console.log(`Found ${mermaidContainers.length} Mermaid containers`);
+        
+        if (mermaidContainers.length === 0) {
+          console.log('No Mermaid diagrams found - proceeding');
+          resolve(true);
+          return;
+        }
+        
+        let renderedCount = 0;
+        let totalDiagrams = mermaidContainers.length;
+        
+        // Check each mermaid container
+        mermaidContainers.forEach((container, index) => {
+          const svg = container.querySelector('svg');
+          if (svg) {
+            // Check if SVG has actual content (not just empty)
+            const hasContent = svg.querySelector('g') || svg.children.length > 0;
+            if (hasContent) {
+              renderedCount++;
+              console.log(`Diagram ${index + 1} is rendered`);
+            } else {
+              console.log(`Diagram ${index + 1} has SVG but no content yet`);
+            }
+          } else {
+            console.log(`Diagram ${index + 1} has no SVG yet`);
+          }
+        });
+        
+        console.log(`${renderedCount}/${totalDiagrams} diagrams rendered`);
+        
+        if (renderedCount === totalDiagrams) {
+          console.log('All Mermaid diagrams are rendered!');
+          // Set window status for wkhtmltopdf
+          window.status = 'mermaid-ready';
+          resolve(true);
+        } else if (checkCount >= maxChecks) {
+          console.warn('Timeout waiting for Mermaid diagrams - proceeding anyway');
+          // Set window status even on timeout
+          window.status = 'mermaid-ready';
+          resolve(false);
+        } else {
+          // Check again in 500ms
+          setTimeout(checkMermaidStatus, 500);
+        }
+      }
+      
+      // Start checking after a brief initial delay
+      setTimeout(checkMermaidStatus, 1000);
+    });
+  }
+  
+  // Wait for DOM to be ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function() {
+      setTimeout(() => {
+        waitForMermaidDiagrams().then((success) => {
+          // Set a global flag that can be checked by wkhtmltopdf
+          window.mermaidReady = true;
+          window.mermaidSuccess = success;
+          window.status = 'mermaid-ready';
+          console.log('Mermaid rendering complete. Ready for PDF generation.');
+          
+          // Also add a visible indicator for debugging
+          const indicator = document.createElement('div');
+          indicator.id = 'mermaid-ready-indicator';
+          indicator.style.display = 'none';
+          indicator.textContent = 'MERMAID_READY';
+          document.body.appendChild(indicator);
+        });
+      }, 500);
+    });
+  } else {
+    setTimeout(() => {
+      waitForMermaidDiagrams().then((success) => {
+        window.mermaidReady = true;
+        window.mermaidSuccess = success;
+        window.status = 'mermaid-ready';
+        console.log('Mermaid rendering complete. Ready for PDF generation.');
+        
+        const indicator = document.createElement('div');
+        indicator.id = 'mermaid-ready-indicator';
+        indicator.style.display = 'none';
+        indicator.textContent = 'MERMAID_READY';
+        document.body.appendChild(indicator);
+      });
+    }, 500);
+  }
+})();

--- a/docs/scripts/test-pdf.js
+++ b/docs/scripts/test-pdf.js
@@ -1,0 +1,47 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function testPDFGeneration() {
+  console.log('Testing basic PDF generation...');
+  
+  const outputPath = path.join(__dirname, '..', 'test-output.pdf');
+  
+  try {
+    // Simple test with a single page
+    const command = [
+      'wkhtmltopdf',
+      '--page-size', 'A4',
+      '--enable-javascript',
+      '--javascript-delay', '3000',
+      '--load-error-handling', 'ignore',
+      'http://localhost:3001',
+      outputPath
+    ].join(' ');
+    
+    console.log('Running command:', command);
+    
+    execSync(command, { stdio: 'inherit' });
+    
+    if (fs.existsSync(outputPath)) {
+      console.log('✅ PDF generated successfully!');
+      console.log('File size:', fs.statSync(outputPath).size, 'bytes');
+      return true;
+    } else {
+      console.log('❌ PDF file not found');
+      return false;
+    }
+  } catch (error) {
+    console.error('❌ Error:', error.message);
+    return false;
+  }
+}
+
+// Start server first
+console.log('Make sure Docusaurus server is running on port 3001');
+console.log('Run: npm run serve -- --port 3001');
+console.log('Then run this test script');
+
+if (require.main === module) {
+  testPDFGeneration();
+}


### PR DESCRIPTION
Fixes Mermaid diagrams not rendering in Docusaurus PDF exports by enhancing CSS and simplifying the PDF generation script.

Mermaid diagrams, being JavaScript-rendered, often fail to appear in PDF exports generated by `wkhtmltopdf` due to timing and rendering issues. This PR addresses this by improving the `print.css` to better style Mermaid elements for print and by introducing a simplified PDF generation script (`generate-pdf-simple.js`) that includes a server readiness check and a sufficient delay to allow Mermaid diagrams to render before PDF creation, without relying on Puppeteer.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3d5ea8a-1980-4dd0-bdb8-f4ec9123e2cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3d5ea8a-1980-4dd0-bdb8-f4ec9123e2cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

