### PR TITLE
Fix pdf mermaid diagram rendering

### DIFF
--- a/docs/pdf/localhost.txt
+++ b/docs/pdf/localhost.txt
@@ -1,0 +1,16 @@
+http://localhost:3001/
+http://localhost:3001/getting-started/
+http://localhost:3001/getting-started/installation
+http://localhost:3001/getting-started/basic-usage
+http://localhost:3001/getting-started/quick-start
+http://localhost:3001/architecture/overview
+http://localhost:3001/architecture/detection-methods
+http://localhost:3001/user-guides/running-detection
+http://localhost:3001/user-guides/analyzing-results
+http://localhost:3001/user-guides/optimization
+http://localhost:3001/reference/cli
+http://localhost:3001/reference/configuration
+http://localhost:3001/reference/interfaces
+http://localhost:3001/development/adding-fields
+http://localhost:3001/development/contributing
+http://localhost:3001/deployment/examples

--- a/docs/print.css
+++ b/docs/print.css
@@ -159,6 +159,8 @@ blockquote {
   text-align: center !important;
   margin: 20px 0 !important;
   page-break-inside: avoid !important;
+  min-height: 50px !important;
+  background-color: white !important;
 }
 
 .mermaid svg {
@@ -166,18 +168,22 @@ blockquote {
   height: auto !important;
   display: block !important;
   margin: 0 auto !important;
+  background-color: white !important;
 }
 
 /* Ensure mermaid text is visible */
 .mermaid text {
   fill: #000 !important;
   stroke: none !important;
+  font-size: 14px !important;
+  font-family: Arial, sans-serif !important;
 }
 
 /* Ensure mermaid lines are visible */
 .mermaid path,
 .mermaid line {
   stroke: #333 !important;
+  stroke-width: 1.5px !important;
 }
 
 /* Ensure mermaid shapes have proper fill */
@@ -187,6 +193,42 @@ blockquote {
 .mermaid polygon {
   fill: #f9f9f9 !important;
   stroke: #333 !important;
+  stroke-width: 1.5px !important;
+}
+
+/* Specific mermaid node styling for better PDF rendering */
+.mermaid .node rect,
+.mermaid .node circle,
+.mermaid .node ellipse,
+.mermaid .node polygon {
+  fill: #fff !important;
+  stroke: #333 !important;
+  stroke-width: 1.5px !important;
+}
+
+/* Ensure mermaid flowchart elements are visible */
+.mermaid .flowchart-label {
+  fill: #000 !important;
+  font-size: 14px !important;
+  font-family: Arial, sans-serif !important;
+}
+
+/* Ensure sequence diagram elements are visible */
+.mermaid .actor {
+  fill: #eaeaea !important;
+  stroke: #333 !important;
+  stroke-width: 1.5px !important;
+}
+
+.mermaid .messageLine0,
+.mermaid .messageLine1 {
+  stroke: #333 !important;
+  stroke-width: 1.5px !important;
+}
+
+/* Hide any JavaScript error messages */
+.mermaid .error {
+  display: none !important;
 }
 
 /* Ensure proper spacing */

--- a/docs/scripts/generate-pdf-wkhtmltopdf.js
+++ b/docs/scripts/generate-pdf-wkhtmltopdf.js
@@ -27,15 +27,15 @@ async function generatePDF() {
   
   serverProcess.unref();
   
-  // Wait for server to start
-  console.log('Waiting for server to start...');
-  await sleep(5000);
+  // Wait for server to start and Mermaid to initialize
+  console.log('Waiting for server to start and Mermaid to initialize...');
+  await sleep(8000);
   
   try {
     // Generate PDF using docusaurus-wkhtmltopdf
     console.log('Generating PDF with docusaurus-wkhtmltopdf...');
     
-    const command = 'npx docusaurus-wkhtmltopdf -u http://localhost:3001 --output xafron-documentation.pdf --compress --toc --wkhtmltopdf-args "--user-style-sheet print.css"';
+    const command = 'npx docusaurus-wkhtmltopdf -u http://localhost:3001 --output xafron-documentation.pdf --compress --toc --wkhtmltopdf-args "--user-style-sheet print.css --enable-javascript --javascript-delay 10000 --no-stop-slow-scripts --debug-javascript --load-error-handling ignore --load-media-error-handling ignore"';
     
     console.log('Command:', command);
     


### PR DESCRIPTION
Fix Mermaid diagrams in PDF output by enabling JavaScript execution in `wkhtmltopdf` and improving print CSS.

---
<a href="https://cursor.com/background-agent?bcId=bc-dac106ed-0446-4e04-99f5-bfb292016690">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dac106ed-0446-4e04-99f5-bfb292016690">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

