### PR TITLE
Fix pdf mermaid diagrams and links

### DIFF
--- a/docs/scripts/generate-pdf-wkhtmltopdf.js
+++ b/docs/scripts/generate-pdf-wkhtmltopdf.js
@@ -66,7 +66,17 @@ async function generatePDF() {
     // Generate PDF using docusaurus-wkhtmltopdf
     console.log('Generating PDF with docusaurus-wkhtmltopdf...');
     
-    const command = 'npx docusaurus-wkhtmltopdf -u http://localhost:3001 --dest . --output xafron-documentation.pdf --toc --wkhtmltopdf-args "--user-style-sheet print.css"';
+    const wkArgs = [
+      '--user-style-sheet print.css',
+      '--enable-internal-links',
+      '--enable-javascript',
+      '--javascript-delay 3000',
+      '--no-stop-slow-scripts',
+      '--print-media-type',
+      '--load-error-handling ignore'
+    ].join(' ');
+
+    const command = `npx docusaurus-wkhtmltopdf -u http://localhost:3001 --dest . --output xafron-documentation.pdf --toc --wkhtmltopdf-args "${wkArgs}"`;
     
     console.log('Command:', command);
     

--- a/docs/scripts/prepare-build-for-pdf.js
+++ b/docs/scripts/prepare-build-for-pdf.js
@@ -24,6 +24,15 @@ function sha1(content) {
   return crypto.createHash('sha1').update(content).digest('hex');
 }
 
+function decodeHtmlEntities(str) {
+  return str
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
 async function renderMermaidToSvg(mermaidCode) {
   // Use Kroki API to render Mermaid to SVG without Puppeteer
   const response = await fetch('https://kroki.io/mermaid/svg', {
@@ -38,47 +47,189 @@ async function renderMermaidToSvg(mermaidCode) {
   return await response.text();
 }
 
-async function processHtmlFile(filePath, outputImagesDir) {
+function isDocRoutePath(p) {
+  // Ignore obvious assets
+  return !/\.(css|js|png|jpg|jpeg|gif|svg|webp|ico|pdf)$/i.test(p) && !p.startsWith('/mermaid/');
+}
+
+function toDocAnchorIdFromPath(docPath) {
+  // Normalize path like "/getting-started/installation/" -> "__pdf_doc_getting-started-installation"
+  let normalized = docPath.replace(/index\.html$/i, '')
+    .replace(/\/index\/?$/i, '/')
+    .replace(/\.html$/i, '')
+    .replace(/\/$/, '');
+  if (!normalized.startsWith('/')) normalized = `/${normalized}`;
+  const slug = normalized.replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '').toLowerCase();
+  return `__pdf_doc_${slug || 'home'}`;
+}
+
+function injectDocAnchor(html, anchorId) {
+  const anchorHtml = `<a name="${anchorId}"><span style="display:none">.</span></a>`;
+  const bodyOpen = html.match(/<body[^>]*>/i);
+  if (bodyOpen) {
+    const idx = bodyOpen.index + bodyOpen[0].length;
+    return html.slice(0, idx) + anchorHtml + html.slice(idx);
+  }
+  return anchorHtml + html;
+}
+
+function rewriteSiteLinksToInternalAnchors(html, knownHostnames) {
+  // Replace hrefs that point to site pages with internal anchors
+  return html.replace(/href="([^"]+)"/g, (match, href) => {
+    try {
+      // Ignore javascript/mailto/tel and fragments
+      if (/^(#|mailto:|tel:|javascript:)/i.test(href)) return match;
+
+      let urlObj;
+      let pathPart = href;
+
+      // Absolute URL
+      if (/^https?:\/\//i.test(href)) {
+        urlObj = new URL(href);
+        if (!knownHostnames.has(urlObj.hostname.toLowerCase())) return match;
+        pathPart = `${urlObj.pathname}`; // ignore query; keep only hash later
+      }
+
+      // Root-relative path
+      if (pathPart.startsWith('/')) {
+        if (!isDocRoutePath(pathPart)) return match;
+        const anchorId = toDocAnchorIdFromPath(pathPart);
+        return `href="#${anchorId}"`;
+      }
+
+      // Relative links (e.g., ../foo)
+      if (!/^([a-z]+:)?\//i.test(pathPart)) {
+        return match;
+      }
+
+      return match;
+    } catch (_) {
+      return match;
+    }
+  });
+}
+
+function rewriteInternalLinks(html) {
+  // Convert absolute site links to site-relative so wkhtmltopdf can keep them internal
+  // Matches href="http(s)://host[:port]/path[?q][#h]"
+  return html.replace(/href="(https?:\/\/[^"?#]+[^\"]*)"/g, (match, url) => {
+    try {
+      const u = new URL(url);
+      const host = (u.hostname || '').toLowerCase();
+      if (
+        host === 'localhost' ||
+        host === '127.0.0.1' ||
+        host === 'docs.xafron.nl'
+      ) {
+        const pathWithHash = `${u.pathname}${u.hash || ''}`;
+        return `href="${pathWithHash}"`;
+      }
+      return match;
+    } catch (_) {
+      return match;
+    }
+  });
+}
+
+function splitHeadBody(html) {
+  const headMatch = html.match(/<head>[\s\S]*?<\/head>/i);
+  const bodyMatch = html.match(/<body[\s\S]*<\/body>/i);
+  if (!headMatch || !bodyMatch) return { head: '', body: html };
+  return { head: headMatch[0], body: bodyMatch[0] };
+}
+
+function extractPagination(html) {
+  const start = html.indexOf('<nav class="docusaurus-mt-lg pagination-nav');
+  if (start === -1) return null;
+  const end = html.indexOf('</nav>', start);
+  if (end === -1) return null;
+  return html.slice(start, end + '</nav>'.length);
+}
+
+function restorePagination(processedBody, originalPagination) {
+  if (!originalPagination) return processedBody;
+  // Replace any modified pagination nav with the original one
+  return processedBody.replace(/<nav class="docusaurus-mt-lg pagination-nav[\s\S]*?<\/nav>/, originalPagination);
+}
+
+async function processHtmlFile(filePath, outputImagesDir, buildDir) {
   let html = await fs.promises.readFile(filePath, 'utf8');
 
+  // 0) Work only on body for link rewriting, keep <head> intact
+  const { head, body } = splitHeadBody(html);
+  let workingBody = body || html;
 
-  // Replace Mermaid blocks with static SVG images
-  const mermaidDivRegex = /<div class="mermaid">([\s\S]*?)<\/div>/g;
+  // 1) Replace Mermaid <div class="mermaid"> blocks with static SVG images
   const replacements = [];
+  const mermaidDivRegex = /<div class="mermaid">([\s\S]*?)<\/div>/g;
   let match;
-  while ((match = mermaidDivRegex.exec(html)) !== null) {
-    const mermaidCode = match[1]
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&amp;/g, '&');
+  while ((match = mermaidDivRegex.exec(workingBody)) !== null) {
+    const mermaidCode = decodeHtmlEntities(match[1]);
     const id = sha1(mermaidCode);
     replacements.push({ start: match.index, end: match.index + match[0].length, code: mermaidCode, id });
   }
 
-  if (replacements.length === 0) {
-    await fs.promises.writeFile(filePath, html, 'utf8');
-    return;
+  // 2) Also handle SSR output that may still contain code fences rendered as <pre><code class="language-mermaid">...</code></pre>
+  const mermaidPreCodeRegex = /<pre[^>]*>\s*<code[^>]*class="[^"]*language-mermaid[^"]*"[^>]*>([\s\S]*?)<\/code>\s*<\/pre>/g;
+  while ((match = mermaidPreCodeRegex.exec(workingBody)) !== null) {
+    const mermaidCode = decodeHtmlEntities(match[1]);
+    const id = sha1(mermaidCode);
+    replacements.push({ start: match.index, end: match.index + match[0].length, code: mermaidCode, id });
   }
 
-  await ensureDir(outputImagesDir);
+  if (replacements.length > 0) {
+    await ensureDir(outputImagesDir);
 
-  // Render and replace sequentially to avoid overwhelming the API
-  let offset = 0;
-  let processedHtml = html;
-  for (const { start, end, code, id } of replacements) {
-    const svgPath = path.join(outputImagesDir, `${id}.svg`);
-    if (!fs.existsSync(svgPath)) {
-      const svg = await renderMermaidToSvg(code);
-      await fs.promises.writeFile(svgPath, svg, 'utf8');
+    // Render and replace sequentially to avoid overwhelming the API
+    let offset = 0;
+    let processedHtml = workingBody;
+    for (const { start, end, code, id } of replacements) {
+      const svgPath = path.join(outputImagesDir, `${id}.svg`);
+      if (!fs.existsSync(svgPath)) {
+        const svg = await renderMermaidToSvg(code);
+        await fs.promises.writeFile(svgPath, svg, 'utf8');
+      }
+      const imgTag = `<img src="/mermaid/${id}.svg" alt="Mermaid diagram" />`;
+      const replaceStart = start + offset;
+      const replaceEnd = end + offset;
+      processedHtml = processedHtml.slice(0, replaceStart) + imgTag + processedHtml.slice(replaceEnd);
+      offset += imgTag.length - (end - start);
     }
-    const imgTag = `<img src="/mermaid/${id}.svg" alt="Mermaid diagram" />`;
-    const replaceStart = start + offset;
-    const replaceEnd = end + offset;
-    processedHtml = processedHtml.slice(0, replaceStart) + imgTag + processedHtml.slice(replaceEnd);
-    offset += imgTag.length - (end - start);
+
+    workingBody = processedHtml;
   }
 
-  await fs.promises.writeFile(filePath, processedHtml, 'utf8');
+  // 3) Inject an internal anchor per page for cross-page linking
+  const relPath = path.relative(buildDir, filePath).replace(/\\/g, '/');
+  // Map .../index.html to route path
+  let routePath = '/' + relPath.replace(/^index\.html$/i, '')
+    .replace(/\/index\.html$/i, '/')
+    .replace(/\.html$/i, '')
+    .replace(/\/+/g, '/');
+  const anchorId = toDocAnchorIdFromPath(routePath);
+  workingBody = injectDocAnchor(workingBody, anchorId);
+
+  // Preserve original pagination for crawler
+  const originalPagination = extractPagination(workingBody);
+
+  // 4) Rewrite absolute production/localhost links to site-relative first (body only)
+  workingBody = rewriteInternalLinks(workingBody);
+
+  // 5) Rewrite site links to internal anchors so they stay within the PDF (body only)
+  const knownHostnames = new Set(['localhost', '127.0.0.1', 'docs.xafron.nl']);
+  workingBody = rewriteSiteLinksToInternalAnchors(workingBody, knownHostnames);
+
+  // 6) Restore pagination nav unchanged
+  workingBody = restorePagination(workingBody, originalPagination);
+
+  // Reassemble document
+  if (head) {
+    html = html.replace(/<head>[\s\S]*?<\/head>/i, head).replace(/<body[\s\S]*<\/body>/i, workingBody);
+  } else {
+    html = workingBody;
+  }
+
+  await fs.promises.writeFile(filePath, html, 'utf8');
 }
 
 async function main() {
@@ -94,10 +245,10 @@ async function main() {
   console.log(`Post-processing ${htmlFiles.length} HTML files for PDF rendering...`);
 
   for (const file of htmlFiles) {
-    await processHtmlFile(file, imagesDir);
+    await processHtmlFile(file, imagesDir, buildDir);
   }
 
-  console.log('Build post-processing complete. Mermaid diagrams rendered and links rewritten.');
+  console.log('Build post-processing complete. Mermaid diagrams rendered and internal links normalized.');
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Enable Mermaid diagram rendering and fix internal links to navigate within the generated PDF.

Previously, Mermaid diagrams were not visible, and internal links pointed to external URLs instead of internal anchors within the PDF. This PR updates the PDF generation scripts to convert Mermaid diagrams to SVGs and rewrite internal links to point to hidden anchors within the document, ensuring proper navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ccae279-94f6-4c9b-a90a-25243458fa7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ccae279-94f6-4c9b-a90a-25243458fa7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

