### PR TITLE
Investigate pdf 404 error

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -82,11 +82,23 @@ jobs:
 
       - name: Verify PDF generation
         run: |
+          ok=0
           if [ -f "static/pdf/xafron-documentation.pdf" ]; then
-            echo "✅ PDF generated successfully"
+            echo "✅ PDF present in static/"
             ls -lh static/pdf/xafron-documentation.pdf
+            ok=1
           else
-            echo "❌ PDF generation failed - file not found"
+            echo "⚠️ PDF missing in static/"
+          fi
+          if [ -f "build/pdf/xafron-documentation.pdf" ]; then
+            echo "✅ PDF present in build/ (deployed site)"
+            ls -lh build/pdf/xafron-documentation.pdf
+            ok=1
+          else
+            echo "⚠️ PDF missing in build/"
+          fi
+          if [ "$ok" -ne 1 ]; then
+            echo "❌ PDF generation failed - file not found in static/ or build/"
             exit 1
           fi
         working-directory: ./docs

--- a/docs/scripts/pandoc-mpdf.js
+++ b/docs/scripts/pandoc-mpdf.js
@@ -162,6 +162,17 @@ async function main() {
   await writeCombined(docsRoot, files, combinedMd);
   runPandoc(docsRoot, combinedMd, outPdf);
   console.log('PDF generated at:', outPdf);
+
+  // Also copy into the built site so it is deployed
+  const buildPdfDir = path.join(docsRoot, 'build', 'pdf');
+  const buildPdfPath = path.join(buildPdfDir, 'xafron-documentation.pdf');
+  try {
+    fs.mkdirSync(buildPdfDir, { recursive: true });
+    fs.copyFileSync(outPdf, buildPdfPath);
+    console.log('PDF copied to build output at:', buildPdfPath);
+  } catch (err) {
+    console.warn('Warning: failed to copy PDF into build directory:', err.message);
+  }
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Copy generated PDF to the build directory and update CI verification to resolve 404 for the PDF on the deployed site.

The Docusaurus build process did not include the PDF generated in `static/pdf` into the final `build/` output, leading to a 404 error when accessing `/pdf/xafron-documentation.pdf`. This change ensures the PDF is present in the deployed artifact.

---
<a href="https://cursor.com/background-agent?bcId=bc-c118bd2a-bb57-45b2-9e76-5e63af118fae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c118bd2a-bb57-45b2-9e76-5e63af118fae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

