### PR TITLE
Revert python to bash in docs

### DIFF
--- a/docs/deployment/examples.md
+++ b/docs/deployment/examples.md
@@ -8,9 +8,8 @@ This document provides example configurations for deploying the Data Quality Det
 
 Run as a batch process from Python:
 
-```python
-import subprocess
-subprocess.run(["python", "main.py", "single-demo", "--data-file", "data.csv"]) 
+```bash
+python main.py single-demo --data-file data.csv
 ```
 
 ## Example 1: Simple Batch Orchestration (Python)

--- a/docs/development/adding-fields.md
+++ b/docs/development/adding-fields.md
@@ -31,13 +31,10 @@ flowchart TD
 
 Understand your field's characteristics:
 
-```python
-# Analyze field data distribution
-import subprocess
-subprocess.run(["python", "analyze_column/analyze_column.py", "data/sample.csv", "new_field_name"]) 
-
+```bash
+python analyze_column/analyze_column.py data/sample.csv new_field_name
 # Or use the main entry point
-subprocess.run(["python", "main.py", "analyze-column", "data/sample.csv", "new_field_name"]) 
+python main.py analyze-column data/sample.csv new_field_name
 ```
 
 ## Step 2: Create a Validator
@@ -142,26 +139,14 @@ for value in ['', 'abc123', '123ABC']:
 
 ### 6.2 Integration Tests
 
-```python
-import subprocess
-subprocess.run([
-  "python", "main.py", "single-demo",
-  "--data-file", "test_data/new_field_test.csv",
-  "--enable-validation", "--enable-pattern", "--enable-ml",
-  "--output-dir", "test_results/new_field",
-])
+```bash
+python main.py single-demo --data-file test_data/new_field_test.csv --enable-validation --enable-pattern --enable-ml --output-dir test_results/new_field
 ```
 
 ### 6.3 Performance Testing
 
-```python
-import subprocess
-subprocess.run([
-  "python", "main.py", "multi-eval",
-  "data/full_dataset.csv", "--field", "new_field",
-  "--num-samples", "100",
-  "--output-dir", "evaluation_results/new_field",
-])
+```bash
+python main.py multi-eval data/full_dataset.csv --field new_field --num-samples 100 --output-dir evaluation_results/new_field
 ```
 
 ## Documentation

--- a/docs/getting-started/basic-usage.md
+++ b/docs/getting-started/basic-usage.md
@@ -38,16 +38,14 @@ flowchart LR
 
 The basic command structure is:
 
-```python
-import subprocess
-subprocess.run(["python", "main.py", "<command>", *"[options]".split()])
+```bash
+python main.py <command> [options]
 ```
 
 For example, to run detection on your data:
 
-```python
-import subprocess
-subprocess.run(["python", "main.py", "single-demo", "--data-file", "your_data.csv"]) 
+```bash
+python main.py single-demo --data-file your_data.csv
 ```
 
 For detailed options and configurations, see the [Running Detection Guide](../user-guides/running-detection.md).
@@ -56,13 +54,8 @@ For detailed options and configurations, see the [Running Detection Guide](../us
 
 The system can inject synthetic errors to evaluate detection performance:
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "clean_data.csv",
-    "--injection-intensity", "0.2",
-])
+```bash
+python main.py single-demo --data-file clean_data.csv --injection-intensity 0.2
 ```
 
 For production use without synthetic errors, set `--injection-intensity 0.0`.
@@ -77,14 +70,8 @@ Note: Detection methods are disabled by default unless you enable them explicitl
 - Speed: Fast
 
 Example:
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--enable-validation",
-    "--validation-threshold", "0.0",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --enable-validation --validation-threshold 0.0
 ```
 
 ### 2. Pattern-Based Detection
@@ -93,14 +80,8 @@ subprocess.run([
 - Speed: Fast
 
 Example:
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--enable-pattern",
-    "--anomaly-threshold", "0.7",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --enable-pattern --anomaly-threshold 0.7
 ```
 
 ### 3. ML-Based Detection
@@ -110,14 +91,8 @@ subprocess.run([
 - Requirement: Trained models
 
 Example:
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--enable-ml",
-    "--ml-threshold", "0.7",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --enable-ml --ml-threshold 0.7
 ```
 
 ### 4. LLM-Based Detection
@@ -127,30 +102,16 @@ subprocess.run([
 - Requirement: Language models
 
 Example:
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--enable-llm",
-    "--llm-threshold", "0.6",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --enable-llm --llm-threshold 0.6
 ```
 
 ## Threshold Configuration
 
 Adjust detection sensitivity per method:
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--validation-threshold", "0.0",
-    "--anomaly-threshold", "0.7",
-    "--ml-threshold", "0.8",
-    "--llm-threshold", "0.6",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --validation-threshold 0.0 --anomaly-threshold 0.7 --ml-threshold 0.8 --llm-threshold 0.6
 ```
 
 ### Threshold Guidelines
@@ -166,13 +127,8 @@ subprocess.run([
 
 Process only essential fields to save memory:
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--core-fields-only",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --core-fields-only
 ```
 
 Core fields typically include:
@@ -188,44 +144,24 @@ Core fields typically include:
 
 Use optimized weights for better accuracy:
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--use-weighted-combination",
-    "--weights-file", "detection_weights.json",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --use-weighted-combination --weights-file detection_weights.json
 ```
 
 ### Generate Weights
 
 Create optimized weights based on performance:
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--injection-intensity", "0.2",
-    "--generate-weights",
-    "--weights-output-file", "custom_weights.json",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --injection-intensity 0.2 --generate-weights --weights-output-file custom_weights.json
 ```
 
 ### LLM Context Enhancement
 
 Provide context for better LLM detection:
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--enable-llm",
-    "--llm-temporal-column", "date_created",
-    "--llm-context-columns", "category,brand,season",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --enable-llm --llm-temporal-column date_created --llm-context-columns category,brand,season
 ```
 
 ## Output Files
@@ -247,59 +183,26 @@ output_dir/
 
 ### 1. Pre-Import Validation
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "import_batch.csv",
-    "--enable-validation",
-    "--validation-threshold", "0.0",
-    "--injection-intensity", "0.0",
-    "--output-dir", "validation_results",
-])
+```bash
+python main.py single-demo --data-file import_batch.csv --enable-validation --validation-threshold 0.0 --injection-intensity 0.0 --output-dir validation_results
 ```
 
 ### 2. Anomaly Detection
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "historical_data.csv",
-    "--enable-pattern", "--enable-ml",
-    "--anomaly-threshold", "0.8",
-    "--ml-threshold", "0.75",
-    "--injection-intensity", "0.0",
-])
+```bash
+python main.py single-demo --data-file historical_data.csv --enable-pattern --enable-ml --anomaly-threshold 0.8 --ml-threshold 0.75 --injection-intensity 0.0
 ```
 
 ### 3. Full System Test
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "test_data.csv",
-    "--injection-intensity", "0.3",
-    "--max-issues-per-row", "2",
-    "--generate-weights",
-    "--output-dir", "test_results",
-])
+```bash
+python main.py single-demo --data-file test_data.csv --injection-intensity 0.3 --max-issues-per-row 2 --generate-weights --output-dir test_results
 ```
 
 ### 4. Production Monitoring
 
-```python
-import subprocess, datetime
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "daily_data.csv",
-    "--injection-intensity", "0.0",
-    "--use-weighted-combination",
-    "--weights-file", "config/production_weights.json",
-    "--core-fields-only",
-    "--output-dir", f"monitoring/{datetime.datetime.now().strftime('%Y%m%d')}",
-])
+```bash
+python main.py single-demo --data-file daily_data.csv --injection-intensity 0.0 --use-weighted-combination --weights-file config/production_weights.json --core-fields-only --output-dir monitoring/$(date +%Y%m%d)
 ```
 
 ## Performance Tips

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -10,15 +10,8 @@ Before starting, ensure you have completed the [Installation Guide](installation
 
 The easiest way to start is with the single sample demo:
 
-```python
-# run_demo.py
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "data/sample_data.csv",
-    "--output-dir", "results/quick_start",
-    "--enable-validation", "--enable-pattern", "--enable-ml",
-])
+```bash
+python main.py single-demo --data-file data/sample_data.csv --output-dir results/quick_start --enable-validation --enable-pattern --enable-ml
 ```
 
 This will:
@@ -51,19 +44,9 @@ Note: `<sample>` defaults to names used by the demo, e.g. `demo_analysis` or `co
 
 Now that you've seen the basic demo, try running with specific detection methods by adjusting the flags you pass in Python:
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "data/sample_data.csv",
-    "--enable-validation",
-])
-
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "data/sample_data.csv",
-    "--enable-pattern",
-])
+```bash
+python main.py single-demo --data-file data/sample_data.csv --enable-validation
+python main.py single-demo --data-file data/sample_data.csv --enable-pattern
 ```
 
 ## What's Next?

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,9 +6,8 @@ This document provides a concise reference for all command-line interfaces in th
 
 The system provides a unified entry point through `main.py`:
 
-```python
-import subprocess
-subprocess.run(["python", "main.py", "<command>"]) 
+```bash
+python main.py <command>
 ```
 
 ### Available Commands
@@ -25,9 +24,8 @@ subprocess.run(["python", "main.py", "<command>"])
 ### single-demo
 Run single sample demonstration with comprehensive detection.
 
-```python
-import subprocess
-subprocess.run(["python", "main.py", "single-demo", "--help"]) 
+```bash
+python main.py single-demo --help
 ```
 
 #### Required
@@ -80,14 +78,8 @@ subprocess.run(["python", "main.py", "single-demo", "--help"])
 ### multi-eval
 Run evaluation across multiple samples for performance analysis.
 
-```python
-import subprocess
-subprocess.run([
-  "python", "main.py", "multi-eval",
-  "data/source.csv", "--field", "material",
-  "--num-samples", "50",
-  "--output-dir", "evaluation_results",
-])
+```bash
+python main.py multi-eval data/source.csv --field material --num-samples 50 --output-dir evaluation_results
 ```
 
 #### Arguments
@@ -112,12 +104,8 @@ subprocess.run([
 ### ml-train
 Train ML-based anomaly detection models or run anomaly checks.
 
-```python
-import subprocess
-subprocess.run([
-  "python", "main.py", "ml-train", "data.csv",
-  "--use-hp-search", "--fields", "material color_name",
-])
+```bash
+python main.py ml-train data.csv --use-hp-search --fields "material color_name"
 ```
 
 Key options:
@@ -129,9 +117,8 @@ Key options:
 ### analyze-column
 Analyze a specific column in a CSV file.
 
-```python
-import subprocess
-subprocess.run(["python", "main.py", "analyze-column", "data/products.csv", "material"]) 
+```bash
+python main.py analyze-column data/products.csv material
 ```
 
 Key options:
@@ -140,13 +127,8 @@ Key options:
 ### ml-curves
 Generate precision-recall and ROC curves for ML-based and LLM-based anomaly detection.
 
-```python
-import subprocess
-subprocess.run([
-  "python", "main.py", "ml-curves", "data/products.csv",
-  "--detection-type", "ml",
-  "--fields", "material color_name",
-])
+```bash
+python main.py ml-curves data/products.csv --detection-type ml --fields "material color_name"
 ```
 
 Key options:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -128,10 +128,9 @@ output_dir/
    print(config.get_column_name('material'))
    ```
 4. Run detection:
-   ```python
-   import subprocess
-   subprocess.run(["python", "main.py", "single-demo", "--data-file", "your_data.csv"]) 
-   ```
+   ```bash
+python main.py single-demo --data-file your_data.csv
+```
 
 ## Best Practices
 

--- a/docs/user-guides/analyzing-results.md
+++ b/docs/user-guides/analyzing-results.md
@@ -20,9 +20,8 @@ print(len(df))  # row count
 
 Use the `analyze-column` command to understand field characteristics:
 
-```python
-import subprocess
-subprocess.run(["python", "main.py", "analyze-column", "your_data.csv", "column_name"]) 
+```bash
+python main.py analyze-column your_data.csv column_name
 ```
 
 This shows:

--- a/docs/user-guides/optimization.md
+++ b/docs/user-guides/optimization.md
@@ -14,26 +14,14 @@ This guide covers evaluating detection performance and optimizing the system for
 
 #### Basic Evaluation
 
-```python
-import subprocess
-subprocess.run([
-  "python", "main.py", "multi-eval",
-  "your_data.csv", "--field", "material",
-  "--num-samples", "100",
-  "--output-dir", "evaluation_results",
-])
+```bash
+python main.py multi-eval your_data.csv --field material --num-samples 100 --output-dir evaluation_results
 ```
 
 #### Field-Specific Evaluation
 
-```python
-import subprocess
-subprocess.run([
-  "python", "main.py", "multi-eval",
-  "your_data.csv", "--field", "color_name",
-  "--ml-detector", "--run", "all",
-  "--num-samples", "50",
-])
+```bash
+python main.py multi-eval your_data.csv --field color_name --ml-detector --run all --num-samples 50
 ```
 
 ## Weighted Combination Optimization
@@ -42,13 +30,8 @@ subprocess.run([
 
 After a single-demo run, use the unified report to generate optimized weights:
 
-```python
-import subprocess
-subprocess.run([
-  "python", "single_sample_multi_field_demo/generate_detection_weights.py",
-  "-i", "results/demo_analysis_unified_report.json",
-  "-o", "detection_weights.json",
-])
+```bash
+python single_sample_multi_field_demo/generate_detection_weights.py -i results/demo_analysis_unified_report.json -o detection_weights.json
 ```
 
 ### Weight Report Structure
@@ -64,43 +47,24 @@ subprocess.run([
 
 ### Using Optimized Weights
 
-```python
-import subprocess
-subprocess.run([
-  "python", "main.py", "single-demo",
-  "--data-file", "your_data.csv",
-  "--use-weighted-combination",
-  "--weights-file", "detection_weights.json",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --use-weighted-combination --weights-file detection_weights.json
 ```
 
 ## Threshold Optimization
 
 Use ML curves to find the best thresholds:
 
-```python
-import subprocess
-subprocess.run([
-  "python", "main.py", "ml-curves", "your_data.csv",
-  "--fields", "material color_name",
-  "--output-dir", "threshold_analysis",
-])
+```bash
+python main.py ml-curves your_data.csv --fields "material color_name" --output-dir threshold_analysis
 ```
 
 This generates precision-recall curves and recommends thresholds.
 
 Apply optimized thresholds:
 
-```python
-import subprocess
-subprocess.run([
-  "python", "main.py", "single-demo",
-  "--data-file", "your_data.csv",
-  "--validation-threshold", "0.0",
-  "--anomaly-threshold", "0.75",
-  "--ml-threshold", "0.82",
-  "--llm-threshold", "0.65",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --validation-threshold 0.0 --anomaly-threshold 0.75 --ml-threshold 0.82 --llm-threshold 0.65
 ```
 
 ## Tuning Strategies

--- a/docs/user-guides/running-detection.md
+++ b/docs/user-guides/running-detection.md
@@ -6,9 +6,8 @@ This guide covers how to run data quality detection on your datasets using vario
 
 The simplest way to run detection is using the demo command:
 
-```python
-import subprocess
-subprocess.run(["python", "main.py", "single-demo", "--data-file", "your_data.csv"]) 
+```bash
+python main.py single-demo --data-file your_data.csv
 ```
 
 This runs detection with default thresholds. Methods are disabled unless enabled with flags.
@@ -17,32 +16,17 @@ This runs detection with default thresholds. Methods are disabled unless enabled
 
 Enable specific detection methods:
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--enable-validation",
-    "--enable-pattern",
-    "--enable-ml",
-    # "--enable-llm",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --enable-validation --enable-pattern --enable-ml
+# add --enable-llm if needed
 ```
 
 ## Setting Detection Thresholds
 
 Adjust sensitivity for each detection method:
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--validation-threshold", "0.0",
-    "--anomaly-threshold", "0.7",
-    "--ml-threshold", "0.7",
-    "--llm-threshold", "0.6",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --validation-threshold 0.0 --anomaly-threshold 0.7 --ml-threshold 0.7 --llm-threshold 0.6
 ```
 
 ### Threshold Guidelines
@@ -56,24 +40,18 @@ subprocess.run([
 
 ### 1. Sample Processing
 
-```python
+```bash
+python - <<'PY'
 import pandas as pd
-# Create a sample file of first 1000 rows
 pd.read_csv("large_data.csv").head(1000).to_csv("sample_data.csv", index=False)
-
-import subprocess
-subprocess.run(["python", "main.py", "single-demo", "--data-file", "sample_data.csv"]) 
+PY
+python main.py single-demo --data-file sample_data.csv
 ```
 
 ### 2. Core Fields Only
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "large_data.csv",
-    "--core-fields-only",
-])
+```bash
+python main.py single-demo --data-file large_data.csv --core-fields-only
 ```
 
 ### 3. Specific Fields
@@ -84,13 +62,8 @@ Note: The single-demo command processes all configured fields. To process specif
 
 ### Specify Output Directory
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--output-dir", "results/2024-01-detection",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --output-dir results/2024-01-detection
 ```
 
 ### Output Files
@@ -104,27 +77,16 @@ The single-demo command generates:
 
 For optimized detection based on historical performance:
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "your_data.csv",
-    "--use-weighted-combination",
-    "--weights-file", "detection_weights.json",
-])
+```bash
+python main.py single-demo --data-file your_data.csv --use-weighted-combination --weights-file detection_weights.json
 ```
 
 ## Injection Testing
 
 Test detection performance with synthetic errors:
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "clean_data.csv",
-    "--injection-intensity", "0.2",
-])
+```bash
+python main.py single-demo --data-file clean_data.csv --injection-intensity 0.2
 ```
 
 Note: Error injection is randomized. The exact errors will vary between runs.
@@ -141,40 +103,20 @@ After detection completes:
 
 ### Quick Quality Check
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "daily_upload.csv",
-    "--enable-pattern",
-])
+```bash
+python main.py single-demo --data-file daily_upload.csv --enable-pattern
 ```
 
 ### Full Production Run
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "production_data.csv",
-    "--enable-validation", "--enable-pattern", "--enable-ml",
-    "--validation-threshold", "0.0",
-    "--anomaly-threshold", "0.6",
-    "--ml-threshold", "0.7",
-    "--output-dir", "results/production_20240101",
-])
+```bash
+python main.py single-demo --data-file production_data.csv --enable-validation --enable-pattern --enable-ml --validation-threshold 0.0 --anomaly-threshold 0.6 --ml-threshold 0.7 --output-dir results/production_20240101
 ```
 
 ### Testing New Configuration
 
-```python
-import subprocess
-subprocess.run([
-    "python", "main.py", "single-demo",
-    "--data-file", "test_data.csv",
-    "--injection-intensity", "0.3",
-    "--enable-validation", "--enable-pattern",
-])
+```bash
+python main.py single-demo --data-file test_data.csv --injection-intensity 0.3 --enable-validation --enable-pattern
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Revert CLI examples in documentation from Python to Bash.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3ddbf7b-d778-43d6-8c83-084ff317fc7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3ddbf7b-d778-43d6-8c83-084ff317fc7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

