### PR TITLE
Train llm models for brand config

### DIFF
--- a/anomaly_detectors/ml_based/main.py
+++ b/anomaly_detectors/ml_based/main.py
@@ -58,6 +58,11 @@ def entry(csv_file=None, use_hp_search=False, hp_trials=15, fields=None, check_a
     brand_config_obj = load_brand_config(brand)
     print(f"Using brand configuration: {brand}")
 
+    # If no fields are specified but brand has field_variations, use those fields
+    if not fields and hasattr(brand_config_obj, 'field_variations') and brand_config_obj.field_variations:
+        fields = list(brand_config_obj.field_variations.keys())
+        print(f"Using fields from brand's field_variations: {', '.join(fields)}")
+
     if check_anomalies:
         field_name = check_anomalies
         print(f"Running anomaly check for field '{field_name}'...")
@@ -212,11 +217,11 @@ if __name__ == "__main__":
     parser.add_argument("csv_file", help="The path to the input CSV file.")
     parser.add_argument("--use-hp-search", action="store_true", help="Use RECALL-FOCUSED hyperparameter search.")
     parser.add_argument("--hp-trials", type=int, default=15, help="Number of hyperparameter search trials (default: 15).")
-    parser.add_argument("--fields", nargs='+', default=None, help="List of field names to include in training/hp search (by field name, space-separated, e.g. 'size material'). If not set, all fields are used.")
+    parser.add_argument("--fields", nargs='+', default=None, help="List of field names to include in training/hp search (by field name, space-separated, e.g. 'size material'). If not set with --brand, uses fields from brand's field_variations. Without --brand, all fields are used.")
     parser.add_argument("--check-anomalies", metavar="FIELD", help="Run anomaly check on the given field using the trained model.")
     parser.add_argument("--threshold", type=float, default=0.6, help="Similarity threshold for anomaly detection (default: 0.6)")
     parser.add_argument("--output", default=None, help="Optional output CSV file for anomaly check results.")
-    parser.add_argument("--brand", help="Brand name (deprecated - uses static config)")
+    parser.add_argument("--brand", help="Brand name. When used without --fields, automatically trains models for all fields in the brand's field_variations.")
     parser.add_argument("--brand-config", help="Path to brand configuration JSON file (deprecated - uses static config)")
     args = parser.parse_args()
 


### PR DESCRIPTION
Align ML training script's `--brand` behavior with LLM script to automatically train all brand-configured fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2061eb2-1da5-4246-8da2-869107e99ec7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2061eb2-1da5-4246-8da2-869107e99ec7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

