### PR TITLE
Split and reassemble large model zip files

### DIFF
--- a/data/LARGE_FILES_HANDLING.md
+++ b/data/LARGE_FILES_HANDLING.md
@@ -1,0 +1,133 @@
+# Large Files Handling Documentation
+
+This document describes how the scripts in the `data/` folder handle files larger than GitHub's 2GB release asset limit.
+
+## Overview
+
+GitHub has a 2GB file size limit for release assets. To handle LLM models that exceed this limit, the scripts now automatically split large zip files into smaller parts and handle merging them back together when downloading.
+
+## Changes Made
+
+### 1. `zip_models_individually.sh`
+- Added automatic detection of zip files larger than 2GB
+- Splits large files into 1900MB parts (to stay well under the 2GB limit)
+- Creates a `.manifest` file with metadata about the split
+- Part files are named: `{model_name}.part1.zip`, `{model_name}.part2.zip`, etc.
+
+### 2. `download.sh`
+- Detects multi-part files by checking for `.manifest` files
+- Automatically downloads all parts
+- Merges parts back into the original zip file
+- Cleans up part files after successful merge
+- Groups multi-part files in discovery mode (filters duplicate entries)
+
+### 3. `extract_models.sh`
+- Detects multi-part models by checking for `.manifest` files
+- Temporarily merges parts before extraction
+- Shows total size across all parts in listings
+- Cleans up temporary merged files after extraction
+
+### 4. `release.sh`
+- Includes all parts and manifest files in releases
+- Provides progress tracking for large uploads
+- Shows summary of successful/failed uploads
+
+## File Structure
+
+For a large model (e.g., `llm_category_baseline.zip` at 2.4GB), the structure becomes:
+
+```
+model_zips/
+└── llm/
+    └── category/
+        ├── llm_category_baseline.manifest     # Metadata file
+        ├── llm_category_baseline.part1.zip    # First 1900MB
+        └── llm_category_baseline.part2.zip    # Remaining data
+```
+
+## Manifest File Format
+
+The `.manifest` file contains:
+```
+# Multi-part zip manifest
+original_file: llm_category_baseline.zip
+total_parts: 2
+split_size: 1900M
+created: 2025-01-21 12:00:00 UTC
+
+# To reconstruct the original file, use:
+# cat llm_category_baseline.part*.zip > llm_category_baseline.zip
+```
+
+## Usage Examples
+
+### Zipping Models (with automatic splitting)
+```bash
+./zip_models_individually.sh
+# Large files are automatically split
+```
+
+### Downloading Models (with automatic merging)
+```bash
+# Download specific model (handles multi-part automatically)
+./download.sh owner/repo tag llm/category/baseline.zip
+
+# Download all baseline models
+./download.sh -v baseline owner/repo tag
+```
+
+### Extracting Models
+```bash
+# Extract specific model (handles multi-part automatically)
+./extract_models.sh llm/category/baseline
+
+# List available models (shows multi-part info)
+./extract_models.sh
+```
+
+### Creating Release
+```bash
+# All parts and manifests are included automatically
+./release.sh data-20250121
+```
+
+## Testing
+
+A test script is provided to verify split/merge functionality:
+```bash
+./test_split_merge.sh
+```
+
+This creates a 2.1GB test file, splits it, merges it back, and verifies checksums match.
+
+## Important Notes
+
+1. **Backward Compatibility**: The scripts maintain compatibility with existing single-file models
+2. **Automatic Handling**: Users don't need to manually handle multi-part files
+3. **Disk Space**: Ensure sufficient disk space for temporary merged files during extraction
+4. **Upload Time**: Multi-part files take longer to upload due to multiple assets
+
+## Troubleshooting
+
+### Missing Parts
+If you see "Cannot extract: missing parts", ensure all part files are downloaded:
+```bash
+# Check what's in the directory
+ls -la model_zips/llm/category/
+```
+
+### Failed Merges
+If merging fails, you can manually merge:
+```bash
+cat model_name.part*.zip > model_name.zip
+```
+
+### Verification
+To verify a multi-part download worked correctly:
+```bash
+# Check file sizes match expected
+du -h model_zips/llm/category/llm_category_baseline.part*.zip
+
+# Try extracting
+unzip -t merged_file.zip
+```

--- a/data/test_split_merge.sh
+++ b/data/test_split_merge.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Test script for verifying split/merge functionality
+
+set -e
+
+echo "🧪 Testing split/merge functionality..."
+
+# Create a test directory
+TEST_DIR="test_split_merge_$(date +%s)"
+mkdir -p "$TEST_DIR"
+cd "$TEST_DIR"
+
+# Create a large test file (2.1GB)
+echo "📝 Creating test file (2.1GB)..."
+dd if=/dev/zero of=large_file.bin bs=1M count=2150 2>/dev/null
+
+# Create a zip file
+echo "📦 Creating zip file..."
+zip -q large_test.zip large_file.bin
+
+# Get original checksum
+ORIGINAL_CHECKSUM=$(md5sum large_file.bin | cut -d' ' -f1)
+echo "🔐 Original checksum: $ORIGINAL_CHECKSUM"
+
+# Test splitting
+echo "🔀 Testing split functionality..."
+MAX_FILE_SIZE=$((2000 * 1024 * 1024))  # 2000 MB
+zip_size=$(stat -c%s large_test.zip 2>/dev/null || stat -f%z large_test.zip 2>/dev/null)
+
+if [ "$zip_size" -gt "$MAX_FILE_SIZE" ]; then
+    echo "  Splitting into 1900MB parts..."
+    split -b 1900M large_test.zip large_test.part
+    
+    # Rename parts
+    part_num=1
+    for part in large_test.part*; do
+        if [ -f "$part" ]; then
+            mv "$part" "large_test.part${part_num}.zip"
+            echo "  Created part ${part_num}: $(du -h "large_test.part${part_num}.zip" | cut -f1)"
+            part_num=$((part_num + 1))
+        fi
+    done
+    
+    # Create manifest
+    {
+        echo "# Multi-part zip manifest"
+        echo "original_file: large_test.zip"
+        echo "total_parts: $((part_num - 1))"
+        echo "split_size: 1900M"
+        echo "created: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+    } > large_test.manifest
+    
+    # Remove original
+    rm -f large_test.zip
+fi
+
+# Test merging
+echo "🔄 Testing merge functionality..."
+if [ -f "large_test.manifest" ]; then
+    total_parts=$(grep "total_parts:" large_test.manifest | cut -d' ' -f2)
+    echo "  Merging $total_parts parts..."
+    
+    cat large_test.part*.zip > large_test_merged.zip
+    
+    # Extract and verify
+    echo "📂 Extracting merged file..."
+    unzip -q large_test_merged.zip
+    
+    # Check checksum
+    MERGED_CHECKSUM=$(md5sum large_file.bin | cut -d' ' -f1)
+    echo "🔐 Merged checksum: $MERGED_CHECKSUM"
+    
+    if [ "$ORIGINAL_CHECKSUM" = "$MERGED_CHECKSUM" ]; then
+        echo "✅ Success! Checksums match - split/merge works correctly"
+    else
+        echo "❌ Error! Checksums don't match"
+        echo "  Original: $ORIGINAL_CHECKSUM"
+        echo "  Merged:   $MERGED_CHECKSUM"
+    fi
+fi
+
+# Cleanup
+cd ..
+echo "🧹 Cleaning up test directory..."
+rm -rf "$TEST_DIR"
+
+echo "✅ Test completed!"


### PR DESCRIPTION
Implements automatic splitting and merging of model zip files to bypass GitHub's 2GB release asset size limit.

---
<a href="https://cursor.com/background-agent?bcId=bc-1137e759-561f-4466-bf07-45a5a8967d8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1137e759-561f-4466-bf07-45a5a8967d8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

